### PR TITLE
Turn off HTML escaping as per the benchmarking rules.

### DIFF
--- a/src/main/java/com/mitchellbosecke/benchmark/MoustacheBenchmark.java
+++ b/src/main/java/com/mitchellbosecke/benchmark/MoustacheBenchmark.java
@@ -1,9 +1,11 @@
 package com.mitchellbosecke.benchmark;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
 
+import com.github.mustachejava.MustacheException;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;
 
@@ -19,7 +21,17 @@ public class MoustacheBenchmark extends BaseBenchmark {
 
     @Setup
     public void setup() {
-        MustacheFactory mustacheFactory = new DefaultMustacheFactory();
+        MustacheFactory mustacheFactory = new DefaultMustacheFactory() {
+          @Override
+          public void encode(String value, Writer writer) {
+            // Disable HTML escaping
+            try {
+              writer.write(value);
+            } catch (IOException e) {
+              throw new MustacheException(e);
+            }
+          }
+        };
         template = mustacheFactory.compile("templates/stocks.mustache.html");
         this.context = getContext();
     }


### PR DESCRIPTION
I'm not sure if the others have this configuration in place as you describe in the README. If they do, then you can merge this and turn off HTML escaping — it is the default behavior for mustache.