### PR TITLE
Add missing link to Handlebars.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ template-benchmark
 JMH benchmark for popular Java template engines:
 
 * [Freemarker](http://freemarker.org/)
+* [Handlebars](https://github.com/jknack/handlebars.java)
 * [Mustache](https://github.com/spullara/mustache.java)
 * [Pebble](http://www.mitchellbosecke.com/pebble)
 * [Rocker](https://github.com/fizzed/rocker)


### PR DESCRIPTION
It was present in the graph but not listed with the other template engines. This will improve SEO.
