### PR TITLE
Add HtmlFlow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<mustache.version>0.9.1</mustache.version>
 		<freemarker.version>2.3.23</freemarker.version>
 		<velocity.version>1.7</velocity.version>
-		<thymeleaf.version>2.1.4.RELEASE</thymeleaf.version>
+		<thymeleaf.version>3.0.9.RELEASE</thymeleaf.version>
 		<junit.version>4.12</junit.version>
 		<trimou.version>1.8.2.Final</trimou.version>
 		<hbs.version>4.0.1</hbs.version>
@@ -101,7 +101,15 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 
 	<dependencies>
@@ -159,6 +167,11 @@
             <groupId>com.fizzed</groupId>
             <artifactId>rocker-runtime</artifactId>
             <version>${rocker.version}</version>
+        </dependency>
+		<dependency>
+            <groupId>com.github.xmlet</groupId>
+            <artifactId>htmlflow</artifactId>
+            <version>3.2</version>
         </dependency>
 
 		<dependency>

--- a/src/main/java/com/mitchellbosecke/benchmark/HtmlFlow.java
+++ b/src/main/java/com/mitchellbosecke/benchmark/HtmlFlow.java
@@ -1,0 +1,25 @@
+package com.mitchellbosecke.benchmark;
+
+import com.mitchellbosecke.benchmark.model.Stock;
+import com.mitchellbosecke.benchmark.templates.StocksHtmlFlow;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+public class HtmlFlow extends BaseBenchmark {
+
+  private List<Stock> stocks;
+
+  @Setup
+  public void setup() throws IOException {
+    this.stocks = Stock.dummyItems();
+  }
+
+  @Benchmark
+  public String benchmark() throws IOException {
+    return StocksHtmlFlow.view.render(stocks);
+  }
+}

--- a/src/main/java/com/mitchellbosecke/benchmark/templates/StocksHtmlFlow.java
+++ b/src/main/java/com/mitchellbosecke/benchmark/templates/StocksHtmlFlow.java
@@ -1,0 +1,138 @@
+package com.mitchellbosecke.benchmark.templates;
+
+import com.mitchellbosecke.benchmark.model.Stock;
+import htmlflow.DynamicHtml;
+import org.xmlet.htmlapifaster.EnumHttpEquivType;
+import org.xmlet.htmlapifaster.EnumMediaType;
+import org.xmlet.htmlapifaster.EnumRelType;
+import org.xmlet.htmlapifaster.EnumTypeContentType;
+import org.xmlet.htmlapifaster.EnumTypeScriptType;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class StocksHtmlFlow {
+
+    public static DynamicHtml<List<Stock>> view = DynamicHtml.view(StocksHtmlFlow::templateStocks);
+
+    private static void templateStocks(DynamicHtml<List<Stock>> view, List<Stock> stocks) {
+        view
+            .html()
+                .head()
+                    .title().text("Stock Prices").__()
+                    .meta()
+                        .attrHttpEquiv(EnumHttpEquivType.CONTENT_TYPE)
+                        .attrContent("text/html; charset=UTF-8")
+                    .__()
+                    .meta()
+                        .addAttr("http-equiv", "Content-Style-Type")
+                        .attrContent("text/CSS")
+                    .__()
+                    .meta()
+                        .addAttr("http-equiv", "Content-Script-Type")
+                        .attrContent("text/javascript")
+                    .__()
+                    .link()
+                        .addAttr("rel", "shortcut icon")
+                        .attrHref("/images/favicon.ico")
+                    .__()
+                    .link()
+                        .attrRel(EnumRelType.STYLESHEET)
+                        .attrType(EnumTypeContentType.TEXT_CSS)
+                        .attrHref("/CSS/style.CSS")
+                        .attrMedia(EnumMediaType.ALL)
+                    .__()
+                    .script()
+                        .attrType(EnumTypeScriptType.TEXT_JAVASCRIPT)
+                        .attrSrc("/js/util.js")
+                    .__()
+                    .style()
+                        .attrType(EnumTypeContentType.TEXT_CSS)
+                        .text(STOCKS_CSS)
+                    .__()
+                .__() // head
+                .body()
+                    .h1().text("Stock Prices").__()
+                    .table()
+                        .thead()
+                            .tr()
+                                .th().text("#").__()
+                                .th().text("symbol").__()
+                                .th().text("name").__()
+                                .th().text("price").__()
+                                .th().text("change").__()
+                                .th().text("ratio").__()
+                            .__() // tr
+                        .__() // thead
+                        .tbody()
+                        .of(tbody -> IntStream
+                            .rangeClosed(1, stocks.size())
+                            .forEach(index -> {
+                                Stock stock = stocks.get(index-1);
+                                tbody
+                                    .tr()
+                                    .dynamic(tr -> tr.attrClass(index % 2 == 0 ? "even" : "odd"))
+                                        .td()
+                                            .dynamic(td -> td.text(index ))
+                                        .__()
+                                        .td()
+                                            .a().dynamic(a -> a.attrHref("/stocks/" + stock.getSymbol()).text(stock.getSymbol())).__()
+                                        .__()
+                                        .td()
+                                            .a().dynamic(a -> a.attrHref(stock.getUrl()).text(stock.getName())).__()
+                                        .__()
+                                        .td()
+                                            .strong().dynamic(strong -> strong.text(stock.getPrice())).__()
+                                        .__()
+                                        .td()
+                                            .dynamic(td -> {
+                                                double change = stock.getChange();
+                                                if (change < 0) {
+                                                    td.attrClass("minus");
+                                                }
+                                                td.text(change);
+                                            })
+                                        .__()
+                                        .td()
+                                            .dynamic(td -> {
+                                                double ratio = stock.getRatio();
+                                                if (ratio < 0) {
+                                                    td.attrClass("minus");
+                                                }
+                                                td.text(ratio);
+                                            })
+                                        .__() // td
+                                    .__(); // tr
+                            })
+                        )
+                        .__() // tbody
+                    .__() // table
+                .__() // body
+            .__(); // html
+    }
+
+    private static final String STOCKS_CSS = "/*<![CDATA[*/\n" +
+        "body {\n" +
+        "\tcolor: #333333;\n" +
+        "\tline-height: 150%;\n" +
+        "}\n" +
+        "\n" +
+        "thead {\n" +
+        "\tfont-weight: bold;\n" +
+        "\tbackground-color: #CCCCCC;\n" +
+        "}\n" +
+        "\n" +
+        ".odd {\n" +
+        "\tbackground-color: #FFCCCC;\n" +
+        "}\n" +
+        "\n" +
+        ".even {\n" +
+        "\tbackground-color: #CCCCFF;\n" +
+        "}\n" +
+        "\n" +
+        ".minus {\n" +
+        "\tcolor: #FF0000;\n" +
+        "}\n" +
+        "\n" +
+        "/*]]>*/";
+}

--- a/src/main/resources/templates/stocks.freemarker.html
+++ b/src/main/resources/templates/stocks.freemarker.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <title>Stock Prices</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
-<meta http-equiv="Content-Script-Type" content="text/javascript" />
-<link rel="shortcut icon" href="/images/favicon.ico" />
-<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<link rel="shortcut icon" href="/images/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 <script type="text/javascript" src="/js/util.js"></script>
 <style type="text/css">
 /*<![CDATA[*/

--- a/src/main/resources/templates/stocks.hbs.html
+++ b/src/main/resources/templates/stocks.hbs.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <title>Stock Prices</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
-<meta http-equiv="Content-Script-Type" content="text/javascript" />
-<link rel="shortcut icon" href="/images/favicon.ico" />
-<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<link rel="shortcut icon" href="/images/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 <script type="text/javascript" src="/js/util.js"></script>
 <style type="text/css">
 /*<![CDATA[*/

--- a/src/main/resources/templates/stocks.mustache.html
+++ b/src/main/resources/templates/stocks.mustache.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<title>Stock Prices</title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<meta http-equiv="Content-Style-Type" content="text/css" />
-	<meta http-equiv="Content-Script-Type" content="text/javascript" />
-	<link rel="shortcut icon" href="/images/favicon.ico" />
-	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<meta http-equiv="Content-Script-Type" content="text/javascript">
+	<link rel="shortcut icon" href="/images/favicon.ico">
+	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 	<script type="text/javascript" src="/js/util.js"></script>
 	<style type="text/css">
 		/*<![CDATA[*/

--- a/src/main/resources/templates/stocks.pebble.html
+++ b/src/main/resources/templates/stocks.pebble.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<title>Stock Prices</title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<meta http-equiv="Content-Style-Type" content="text/css" />
-	<meta http-equiv="Content-Script-Type" content="text/javascript" />
-	<link rel="shortcut icon" href="/images/favicon.ico" />
-	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<meta http-equiv="Content-Script-Type" content="text/javascript">
+	<link rel="shortcut icon" href="/images/favicon.ico">
+	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 	<script type="text/javascript" src="/js/util.js"></script>
 	<style type="text/css">
 		/*<![CDATA[*/

--- a/src/main/resources/templates/stocks.rocker.raw
+++ b/src/main/resources/templates/stocks.rocker.raw
@@ -5,11 +5,11 @@
 <html>
 <head>
 <title>Stock Prices</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
-<meta http-equiv="Content-Script-Type" content="text/javascript" />
-<link rel="shortcut icon" href="/images/favicon.ico" />
-<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<link rel="shortcut icon" href="/images/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 <script type="text/javascript" src="/js/util.js"></script>
 <style type="text/css">
 /*<![CDATA[*/

--- a/src/main/resources/templates/stocks.thymeleaf.html
+++ b/src/main/resources/templates/stocks.thymeleaf.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<title>Stock Prices</title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<meta http-equiv="Content-Style-Type" content="text/css" />
-	<meta http-equiv="Content-Script-Type" content="text/javascript" />
-	<link rel="shortcut icon" href="/images/favicon.ico" />
-	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<meta http-equiv="Content-Script-Type" content="text/javascript">
+	<link rel="shortcut icon" href="/images/favicon.ico">
+	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 	<script type="text/javascript" src="/js/util.js"></script>
 	<style type="text/css">
 		/*<![CDATA[*/
@@ -55,7 +55,7 @@
 		<tbody>
 <!--/* Note that itemStat.odd works with index (starting with 0) whereas itemStat.count is starting with 1 */-->
 			<tr th:each="item: ${items}"
-				th:class="${itemStat.odd}? 'even' : 'odd'">
+				th:class="${itemStat.odd}? 'odd' : 'even'">
 				<td th:utext="${itemStat.count}"></td>
 				<td><a th:href="${'/stocks/' + item.symbol}"
 					th:utext="${item.symbol}"></a></td>

--- a/src/main/resources/templates/stocks.trimou.html
+++ b/src/main/resources/templates/stocks.trimou.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <title>Stock Prices</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
-<meta http-equiv="Content-Script-Type" content="text/javascript" />
-<link rel="shortcut icon" href="/images/favicon.ico" />
-<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<link rel="shortcut icon" href="/images/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 <script type="text/javascript" src="/js/util.js"></script>
 <style type="text/css">
 /*<![CDATA[*/

--- a/src/main/resources/templates/stocks.velocity.html
+++ b/src/main/resources/templates/stocks.velocity.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<title>Stock Prices</title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<meta http-equiv="Content-Style-Type" content="text/css" />
-	<meta http-equiv="Content-Script-Type" content="text/javascript" />
-	<link rel="shortcut icon" href="/images/favicon.ico" />
-	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<meta http-equiv="Content-Script-Type" content="text/javascript">
+	<link rel="shortcut icon" href="/images/favicon.ico">
+	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 	<script type="text/javascript" src="/js/util.js"></script>
 	<style type="text/css">
 		/*<![CDATA[*/

--- a/src/test/java/com/mitchellbosecke/benchmark/ExpectedOutputTest.java
+++ b/src/test/java/com/mitchellbosecke/benchmark/ExpectedOutputTest.java
@@ -81,8 +81,17 @@ public class ExpectedOutputTest {
         assertOutput(hbs.benchmark());
     }
 
+    @Test
+    public void testHtmlFlowOutput() throws IOException {
+        HtmlFlow hf = new HtmlFlow();
+        hf.setup();
+        assertOutput(hf.benchmark());
+    }
+
     private void assertOutput(final String output) throws IOException {
-        assertEquals(readExpectedOutputResource(), output.replaceAll("\\s", ""));
+        assertEquals(
+            readExpectedOutputResource().toLowerCase(),
+            output.replaceAll("\\s", "").toLowerCase());
     }
 
     private String readExpectedOutputResource() throws IOException {

--- a/src/test/resources/expected-output.html
+++ b/src/test/resources/expected-output.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <title>Stock Prices</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
-<meta http-equiv="Content-Script-Type" content="text/javascript" />
-<link rel="shortcut icon" href="/images/favicon.ico" />
-<link rel="stylesheet" type="text/css" href="/css/style.css" media="all" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<link rel="shortcut icon" href="/images/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
 <script type="text/javascript" src="/js/util.js"></script>
 <style type="text/css">
 /*<![CDATA[*/


### PR DESCRIPTION
[HtmlFlow](https://github.com/xmlet/HtmlFlow)  is a Java DSL to write typesafe HTML documents.   

Issue: #25 

HtmlFlow competes with the most performant template engine, i.e. Rocker and is faster than the remaining concurrency.

HtmlFlow is widely used to build dynamic HTML documents, such as papers, reports, emails, etc, involving complex programing tasks which are hardly achieved through textual templates. Moreover, HtmlFlow can also be used as a web template engine allying its performance boost with its HTML strongly type safety characteristics.
