### PR TITLE
Update rocker.version and add javax.annotation-api as dependency to fix build with java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<junit.version>4.12</junit.version>
 		<trimou.version>1.8.2.Final</trimou.version>
 		<hbs.version>4.0.1</hbs.version>
-		<rocker.version>0.10.3</rocker.version>
+		<rocker.version>1.2.1</rocker.version>
 	</properties>
 
 	<licenses>
@@ -117,6 +117,11 @@
 			<artifactId>jmh-generator-annprocess</artifactId>
 			<version>${jmh.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.1</version>
 		</dependency>
 
 		<!-- template engines -->


### PR DESCRIPTION
Fix the following build error:

[INFO] --- rocker-maven-plugin:0.10.3:generate (generate-rocker-templates) @ template-benchmark ---
[INFO] Property rocker.javaVersion not set. Using your JDK version 11.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.733 s
[INFO] Finished at: 2019-03-31T19:56:24+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.fizzed:rocker-maven-plugin:0.10.3:generate (generate-rocker-templates) on project template-benchmark: Unsupported javaVersion [11.] -> [Help 1]