### PR TITLE
upgrade templates to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,18 +11,20 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jmh.version>1.11.2</jmh.version>
+		<jmh.version>1.22</jmh.version>
 		<uberjar.name>benchmarks</uberjar.name>
 
-		<pebble.version>2.2.0</pebble.version>
-		<mustache.version>0.9.1</mustache.version>
-		<freemarker.version>2.3.23</freemarker.version>
+		<pebble.version>2.4.0</pebble.version>
+		<mustache.version>0.9.6</mustache.version>
+		<freemarker.version>2.3.29</freemarker.version>
 		<velocity.version>1.7</velocity.version>
-		<thymeleaf.version>2.1.4.RELEASE</thymeleaf.version>
+		<thymeleaf.version>3.0.11.RELEASE</thymeleaf.version> 
 		<junit.version>4.12</junit.version>
-		<trimou.version>1.8.2.Final</trimou.version>
-		<hbs.version>4.0.1</hbs.version>
-		<rocker.version>0.10.3</rocker.version>
+		<trimou.version>2.5.0.Final</trimou.version>
+		<hbs.version>4.1.2</hbs.version>
+		<rocker.version>1.2.2</rocker.version>
+
+
 	</properties>
 
 	<licenses>
@@ -45,10 +47,10 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<pebble.version>3.1.2</pebble.version>
 		<mustache.version>0.9.6</mustache.version>
 		<freemarker.version>2.3.29</freemarker.version>
-		<velocity.version>1.7</velocity.version>
+		<velocity.version>2.1</velocity.version>
 		<thymeleaf.version>3.0.11.RELEASE</thymeleaf.version> 
 		<junit.version>4.12</junit.version>
 		<trimou.version>2.5.0.Final</trimou.version>
@@ -139,7 +139,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.velocity</groupId>
-			<artifactId>velocity</artifactId>
+			<artifactId>velocity-engine-core</artifactId>
 			<version>${velocity.version}</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<jmh.version>1.22</jmh.version>
 		<uberjar.name>benchmarks</uberjar.name>
 
-		<pebble.version>2.4.0</pebble.version>
+		<pebble.version>3.1.2</pebble.version>
 		<mustache.version>0.9.6</mustache.version>
 		<freemarker.version>2.3.29</freemarker.version>
 		<velocity.version>1.7</velocity.version>
@@ -123,7 +123,7 @@
 
 		<!-- template engines -->
 		<dependency>
-			<groupId>com.mitchellbosecke</groupId>
+			<groupId>io.pebbletemplates</groupId>
 			<artifactId>pebble</artifactId>
 			<version>${pebble.version}</version>
 		</dependency>

--- a/src/main/java/com/mitchellbosecke/benchmark/Freemarker.java
+++ b/src/main/java/com/mitchellbosecke/benchmark/Freemarker.java
@@ -21,7 +21,7 @@ public class Freemarker extends BaseBenchmark {
 
     @Setup
     public void setup() throws IOException {
-        Configuration configuration = new Configuration(Configuration.VERSION_2_3_22);
+        Configuration configuration = new Configuration(Configuration.VERSION_2_3_29);
         configuration.setTemplateLoader(new ClassTemplateLoader(getClass(), "/"));
         template = configuration.getTemplate("templates/stocks.freemarker.html");
         this.context = getContext();

--- a/src/main/resources/templates/stocks.thymeleaf.html
+++ b/src/main/resources/templates/stocks.thymeleaf.html
@@ -55,7 +55,7 @@
 		<tbody>
 <!--/* Note that itemStat.odd works with index (starting with 0) whereas itemStat.count is starting with 1 */-->
 			<tr th:each="item: ${items}"
-				th:class="${itemStat.odd}? 'even' : 'odd'">
+				th:class="${itemStat.odd}? 'odd' : 'even'">
 				<td th:utext="${itemStat.count}"></td>
 				<td><a th:href="${'/stocks/' + item.symbol}"
 					th:utext="${item.symbol}"></a></td>

--- a/src/main/resources/templates/stocks.velocity.html
+++ b/src/main/resources/templates/stocks.velocity.html
@@ -54,9 +54,9 @@
 		</thead>
 		<tbody>
 		#foreach($item in $items)
-			#if($velocityCount % 2 == 0) #set($klass = "even") #else #set($klass = "odd") #end
+			#if($foreach.count % 2 == 0) #set($klass = "even") #else #set($klass = "odd") #end
 			<tr class="${klass}">
-				<td>${velocityCount}</td>
+				<td>${foreach.count}</td>
 			    <td>
 			    	<a href="/stocks/${item.symbol}">${item.symbol}</a>
 			    </td>


### PR DESCRIPTION
1. upgrade template engine versions to latest available version: 
```<pebble.version>3.1.2</pebble.version> <!-- Dec, 2019 -->
<mustache.version>0.9.6</mustache.version> <!-- Jan, 2019 -->
<freemarker.version>2.3.29</freemarker.version> <!-- Aug, 2019 -->
<velocity.version>2.1</velocity.version> <!-- Mar, 2019 -->
<thymeleaf.version>3.0.11.RELEASE</thymeleaf.version> <!-- Oct, 2018 -->
<trimou.version>2.5.0.Final</trimou.version> <!-- May, 2018 -->
<hbs.version>4.1.2</hbs.version> <!-- Oct, 2018-->
<rocker.version>1.2.2</rocker.version>  <!-- Sep, 2019 -->
```
2. upgrade 3rd party benchmark tool version
```
<jmh.version>1.22</jmh.version> <!-- Nov, 2019 -->
```

3. upgrade code to java8 
